### PR TITLE
Fix for missing clmapi.proto while installation

### DIFF
--- a/clmprotowrapper/pyproject.toml
+++ b/clmprotowrapper/pyproject.toml
@@ -32,3 +32,4 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry]
 build = "build.py"
 packages = [{include = "clmprotowrapper"}]
+include = ["clmapi.proto"]


### PR DESCRIPTION
Currently pyproject.toml only includes the folder `clmprotowrapper` which discards the `clmapi.proto` file and hence the package installation fails.

This PR is intended to fix this